### PR TITLE
Fix for failing actions with nightly build

### DIFF
--- a/src/Documents/Operations/Indexes/GetIndexesStatisticsCommand.php
+++ b/src/Documents/Operations/Indexes/GetIndexesStatisticsCommand.php
@@ -31,8 +31,14 @@ class GetIndexesStatisticsCommand extends RavenCommand
         if ($response == null) {
             self::throwInvalidResponse();
         }
+        $responseData = json_decode($response, true);
 
-        $this->result = $this->getMapper()->deserialize($response, $this->getResultClass(), 'json');
+        $resultsData = [];
+        if (array_key_exists('Results', $responseData)) {
+            $resultsData = $responseData['Results'];
+        }
+
+        $this->result = $this->getMapper()->denormalize($resultsData, $this->getResultClass());
     }
 
     public function isReadRequest(): bool

--- a/tests/Driver/RavenTestDriver.php
+++ b/tests/Driver/RavenTestDriver.php
@@ -322,7 +322,7 @@ abstract class RavenTestDriver extends TestCase
                 }
 
                 if ($sw->elapsed() > $timeout->getSeconds()) {
-                    return $currentVal;
+                    throw new RuntimeException('Expected value: ' . $currentVal . ', never received.');
                 }
             } catch (\Throwable $exception) {
                 if ($sw->elapsed() > $timeout->getSeconds()) {


### PR DESCRIPTION

Bug fix: IndexOperationsTest::testGetCanIndexesStats was failing