### PR TITLE
allow Symfony HTTP Client v7.1 as a dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "ramsey/uuid": "^4.2",
         "symfony/http-client": "^7.1 || ^6.1",
         "symfony/mime": "^6.1",
-        "symfony/property-access": "^6.1",
+        "symfony/property-access": "^7.1.4 || ^6.1",
         "symfony/serializer": "^6.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "doctrine/annotations": "^1.13",
         "doctrine/inflector": "^2.0",
         "ramsey/uuid": "^4.2",
-        "symfony/http-client": "^6.1",
+        "symfony/http-client": "^7.1 || ^6.1",
         "symfony/mime": "^6.1",
         "symfony/property-access": "^6.1",
         "symfony/serializer": "^6.1"


### PR DESCRIPTION
There may be more dep updates needed. Please advise if this is an acceptable request to make.